### PR TITLE
Attribution bugfix

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -62,6 +62,8 @@ The following base animations:
 Oversized spear
 Oversized male longsword
 Oversized male rapier
+dark2 skinned color tones
+grey eyes (male and female)
 
 Marcel van de Steeg
 -------------------
@@ -164,11 +166,6 @@ green pants (f)
 ponytail2 hairstyle (f)
 plain hairstyle (m)
 hairstyle autoposition/recolor script
-
-Mark Weyer
-----------
-dark2 (male and female)
-grey eyes (male and female)
 
 Barbara Rivera
 --------------


### PR DESCRIPTION
AUTHORS.txt listed me as the author of the dark2 skin and matching eyes.
I was the one who brought these into the Universal Sprite Sheet, but I took it from Johannes Sjölund's LPC entry (the subdirectory "examples").
